### PR TITLE
PR-652 Add ephemeral key support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+networks:
+  app-tier:
+    driver: bridge
+services:
+  localstripe:
+    build: .
+    ports: 
+      - 8420:8420
+    environment:
+      - DD_TRACE_ENABLED=false
+      - DD_PROFILING_ENABLED=false
+      - DD_PROFILING_HEAP_ENABLED=false
+    depends_on:
+      - localstripe-redis
+    networks:
+      - app-tier
+    volumes:
+      - ./localstripe/:/app
+  localstripe-redis:
+    image: "bitnami/redis-sentinel"
+    environment:
+      - REDIS_SENTINEL_TLS_AUTH_CLIENTS='no'
+    ports:
+      - '26379:26379'
+    networks:
+      - app-tier
+    depends_on:
+      - redis
+  redis:
+    image: 'bitnami/redis:latest'
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    networks:
+      - app-tier
+    ports:
+      - '6379'

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3981,3 +3981,23 @@ class IssuingPaymentTransaction(StripeObject):
         self.wallet = wallet
 
         redis_master.set(self._store_key(), pickle.dumps(self))
+
+class EphemeralKey(StripeObject):
+    object = 'ephemeral_key'
+    _id_prefix = 'ephkey_'
+    _id_length = 24
+
+    def __init__(self, issuing_card: str = None):
+
+        try:
+            assert _type(issuing_card) is str
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        super().__init__()
+
+        self.associated_objects = [{"id": issuing_card, "type": "issuing.card"}]
+        self.secret = f'req_{random_id(24)}'
+        self.expires = int(time.time()) + 3600 
+
+        redis_master.set(self._store_key(), pickle.dumps(self))

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -34,7 +34,7 @@ from .resources import BalanceTransaction, Charge, Coupon, Customer, Event, \
     Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, \
     Product, Refund, SetupIntent, Source, Subscription, SubscriptionItem, \
     TaxRate, Token, extra_apis, redis_master, redis_slave, IssuingCard, IssuingCardholder, fetch_all, \
-    IssuingAuthorization
+    IssuingAuthorization, EphemeralKey
 
 from .errors import UserError
 from .webhooks import register_webhook, Webhook
@@ -320,14 +320,18 @@ for cls in (IssuingAuthorization,):
             ('GET', '/v1/' + cls.object.replace('.', '/') + 's', api_list_all)):
         app.router.add_route(method, url, func(cls, url))
 
-
-
 def localstripe_js(request):
     path = os.path.dirname(os.path.realpath(__file__)) + '/localstripe-v3.js'
     with open(path) as f:
         return web.Response(text=f.read(),
                             content_type='application/javascript')
 
+# Ephemeral Key Support
+for cls in (EphemeralKey,):
+    for method, url, func in (
+            ('POST', '/v1/' + cls.object + 's', api_create),
+            ('DELETE', '/v1/' + cls.object + 's/{id}', api_delete)):
+        app.router.add_route(method, url, func(cls, url))
 
 app.router.add_get('/js.stripe.com/v3/', localstripe_js)
 


### PR DESCRIPTION
This adds Ephemeral Key as an API resource, which is used in adding cards to users' digital wallets.

Also introduced `docker-compose` with redis dependencies to make local development easier. 