### PR TITLE
PR-652 Fix Issuing Authorization Metadata

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3775,7 +3775,7 @@ class IssuingAuthorization(StripeObject):
             "postal_code": "10003",
             "state": "NY"
         } # Note - May be necessary for this to contain actual values
-        self.metadata = metadata
+        self.metadata = metadata or {}
         self.pending_request = {
             'amount': charge.amount,
             'amount_details': {


### PR DESCRIPTION
This returns an empty object instead of `null` in the Authorization metadata field. This is the expected value from the Stripe API